### PR TITLE
Fix file extensions YAML

### DIFF
--- a/Hog.sublime-syntax
+++ b/Hog.sublime-syntax
@@ -5,7 +5,10 @@ name: Hog
 version: 1
 hidden: false
 file_extensions:
-  - [src, sim, lst, con]
+  - src
+  - sim
+  - lst
+  - con
 scope: source.hog
 
 contexts:


### PR DESCRIPTION
You can either do `file_extensions: [foo, bar, etc]` or newlines with `-`. Don't do both. :slightly_smiling_face: